### PR TITLE
Removed "No catch-all" from mailbox.org

### DIFF
--- a/src/data.yml
+++ b/src/data.yml
@@ -193,7 +193,7 @@ mailProviders:
       (Standard Plan, €3.00/m)
     level: 2
   aliases:
-    text: 25 aliases (Standard Plan). No catch-all
+    text: 25 aliases (Standard Plan).
     level: 2
   webClientAccess:
     text: Yes (IMAP, POP3)


### PR DESCRIPTION
Mailbox supports catch-all domains under "Aliases for your custom domain name" with a shared limit of 50 catch-all and aliases for custom domains. The 50 limit is seperate to the 25 available aliases under the maibox.org domain

https://mailbox.org/en/services#tariffs
https://kb.mailbox.org/en/private/custom-domains/how-to-set-up-a-catch-all-alias-with-a-custom-domain-name

