### PR TITLE
Mailfence accepts BTC and LTC for payments.

### DIFF
--- a/src/data.yml
+++ b/src/data.yml
@@ -161,8 +161,8 @@ mailProviders:
     text: 'No'
     level: 3
   acceptsCrypto:
-    text: No (Card, PayPal)
-    level: 3
+    text: Yes (BTC and LTC)
+    level: 1
   personalInfoRequired:
     text: Recovery Email Only
     level: 1


### PR DESCRIPTION
Source: 
- https://blog.mailfence.com/mailfence-accepts-bitcoins-for-payment/
- https://blog.mailfence.com/mailfence-accepts-litecoin-payments/