### PR TITLE
Updates

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ const columnMap = new Map([
   ['openSource', 'Open Source'],
   ['onionSite', 'Onion Site'],
   ['pricing', 'Pricing'],
-  ['domainSupport', 'Custom Domain'],
+  ['customDomain', 'Custom Domain'],
   ['aliases', 'Aliases'],
   ['webClientAccess', 'External Access'],
   ['securityAudit', 'Security Audited'],

--- a/src/data.yml
+++ b/src/data.yml
@@ -206,7 +206,7 @@ mailProviders:
     level: 1
   mobileApp:
     text: No (PWA Only)
-    level: 3
+    level: 2
   activeDevelopment:
     text: 'Unknown'
     level: 0
@@ -557,7 +557,7 @@ mailProviders:
     level: 2
   mobileApp:
     text: No (PWA Only)
-    level: 3
+    level: 2
   activeDevelopment:
     text: 'Yes'
     level: 1

--- a/src/data.yml
+++ b/src/data.yml
@@ -541,7 +541,7 @@ mailProviders:
     text: |
       Yes
       Unlimited aliases
-      No catch-all
+      Catch-all (only for custom domains)
     level: 2
   webClientAccess:
     text: Yes (IMAP, SMTP)

--- a/src/data.yml
+++ b/src/data.yml
@@ -553,8 +553,8 @@ mailProviders:
     text: Yes (BTC only, but only personal accounts)
     level: 2
   personalInfoRequired:
-    text: Full name, recovery email
-    level: 2
+    text: None
+    level: 1
   mobileApp:
     text: No (PWA Only)
     level: 2

--- a/src/data.yml
+++ b/src/data.yml
@@ -523,7 +523,7 @@ mailProviders:
     level: 1
   openSource:
     text: 'No'
-    level: 1
+    level: 3
   onionSite:
     text: 'No'
     level: 3

--- a/src/data.yml
+++ b/src/data.yml
@@ -24,7 +24,7 @@ mailProviders:
       Paid plans start from €5 and allow for additional
       features, custom domain, and increased message volume
     level: 1
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Plus Plan, €5.00/m)
@@ -76,7 +76,7 @@ mailProviders:
       for a custom domain, 5 alias addresses and
       improved search and filters
     level: 1
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Premium Plan, €1.00/m)
@@ -130,7 +130,7 @@ mailProviders:
       50 MB attachments, email analytics, read receipts, aliases,
       and a catch-all email.
     level: 1
-  domainSupport:
+  customDomain:
     text: |- 
       Yes
       (Business plan, $15/m)
@@ -182,7 +182,7 @@ mailProviders:
       domain, 10 aliases, mail client access and
       increased message volume
     level: 1
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Entry Plan, €2.50/m)
@@ -232,7 +232,7 @@ mailProviders:
       No free plan. Starts at €1 / month.
       Increases to €9 for all features and storage
     level: 2
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Standard Plan, €3.00/m)
@@ -283,7 +283,7 @@ mailProviders:
     text: |
       No free plan, flat fee of €3.25 / month for everything
     level: 2
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Paid Plan, €3.25)
@@ -331,7 +331,7 @@ mailProviders:
   pricing:
     text: No free plan. Pricing is €1 / month
     level: 2
-  domainSupport:
+  customDomain:
     text: 'No'
     level: 3
   aliases:
@@ -381,7 +381,7 @@ mailProviders:
       single domain, going up to €69.95 / year for
       more storage and domains
     level: 2
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Micro Plan, €1.25/m)
@@ -432,7 +432,7 @@ mailProviders:
       No free plan. Starts at CHF 5.00 / mo, basic
       features only. Groupware account is CHF 9.90
     level: 2
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Group Plan, CHF 9.90/m)
@@ -481,7 +481,7 @@ mailProviders:
     text: |
       No free plan. Pricing is $4.83 / month
     level: 2
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Paid Plan + $15 setup fee)
@@ -530,9 +530,9 @@ mailProviders:
   pricing:
     text: |
       No free plan. Starts at $5 / month,
-      but without custom domain support
+      but without custom domain feature
     level: 2
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Domain Plan, $5.85)
@@ -583,7 +583,7 @@ mailProviders:
   pricing:
     text: Free, payment set for each additional feature
     level: 1
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Donation required)
@@ -629,9 +629,9 @@ mailProviders:
   pricing:
     text: |
       No free plan. Starts at $5.99 / month,
-      rising to $7.99 for email archiving support
+      rising to $7.99 for email archiving feature
     level: 2
-  domainSupport:
+  customDomain:
     text: |
       Yes
       (Business Plan, $5.99/m)
@@ -682,7 +682,7 @@ mailProviders:
       Pricing ranges from $30 - $60 / year,
       depending on storage requirements
     level: 2
-  domainSupport:
+  customDomain:
     text: 'No'
     level: 3
   aliases:


### PR DESCRIPTION
## General changes:

- Mobile app PWA only can be level 2, IMO.

- In pricing, rephrased `support` to `feature` not to mistake it with actual customer support.

## StartMail changes:

- Fixed the level of `No` in Open Source.

- Required Info. Name and recovery email address are optional: https://www.startmail.com/en/privacy/
> A name that you choose (optional and may be an alias or pseudonym, but see also our Terms of Service, → to be able to address you when we communicate with you.
> ...
> A Recovery Email Address (optional, see also our Terms of Service), → to communicate with you in the event that you need to recover access to your StartMail Account should you ever lose your password.
  
- Catch-all feature is now available for custom domain accounts: https://www.startmail.com/en/release-notes-july-2022/

I did those changes in separate commits so feel free to cherry-pick them if you like.

---

Disclaimer: I'm an employee of StartMail.