### PR TITLE
Set the Criptext juridiction to United States since it's where the company is located

### DIFF
--- a/src/data.yml
+++ b/src/data.yml
@@ -111,8 +111,8 @@ mailProviders:
   link: https://criptext.com/
   icon: https://i.ibb.co/tKhzqJR/criptext.png
   jurisdiction:
-    text: Decentralized
-    level: 0
+    text: United States (5 Eyes)
+    level: 3
   encryption:
     text: Signal Protocol
     level: 2


### PR DESCRIPTION
This PR sets the Criptext juridiction to United States since it's where the company is located ( https://criptext.com/en/terms 11.2: "The Service is controlled and offered by Company from its facilities in the United States of America.")

It doesn't matter that the content is decentralized. If the company (the data controller) is in the US (and it is) it's where you data is being controlled from, it's especially a problem if the company is in the US (and it is).