### PR TITLE
Modify Mailbox.org onionSite

### DIFF
--- a/src/data.yml
+++ b/src/data.yml
@@ -225,8 +225,8 @@ mailProviders:
     text: 'No'
     level: 3
   onionSite:
-    text: 'No'
-    level: 3
+    text: 'Yes'
+    level: 1
   pricing:
     text: |
       No free plan. Starts at €1 / month.


### PR DESCRIPTION
Mailbox.org operates an exit note (see https://kb.mailbox.org/service-desk/faq-article/the-tor-exit-node-of-mailbox-org)