### PR TITLE
feat: added Forward Email

### DIFF
--- a/src/data.yml
+++ b/src/data.yml
@@ -2,6 +2,52 @@
 # List of mail providers (in no order)
 # Level indicates color (0 = N/A, 1 = Great, 2 = Okay, 3 = Bad)
 mailProviders:
+# Forward Email
+- name: Forward Email
+  link: https://forwardemail.net
+  icon: https://github.com/forwardemail/forwardemail.net/raw/master/assets/img/logo-square-30-30.svg
+  jurisdiction:
+    text: United States (5 Eyes)
+    level: 3
+  encryption:
+    text: PGP
+    level: 1
+  openSource:
+    text: 'Yes'
+    level: 1
+  onionSite:
+    text: N/A (No webmail)
+    level: 0
+  pricing:
+    text: |
+      Free Plan - unlimited domains, aliases, and custom domains.
+      Paid plans start from $3/mo and allow SMTP, IMAP, POP3, and API access
+    level: 1
+  customDomain:
+    text: 'Yes (Unlimited)'
+    level: 1
+  aliases:
+    text: 'Yes (Unlimited)'
+    level: 1
+  webClientAccess:
+    text: N/A (No webmail yet, but you can use an [open source webmail client](https://forwardemail.net/blog/open-source/web-email-clients) or Gmail, Apple Mail, Thunderbird, etc)
+    level: 0
+  securityAudit:
+    text: 'N/A (100% open-source on GitHub)'
+    level: 1
+  acceptsCrypto:
+    text: 'No'
+    level: 2
+  personalInfoRequired:
+    text: 'No'
+    level: 1
+  mobileApp:
+    text: N/A (Supports [Apple Mail on iOS](https://forwardemail.net/blog/open-source/apple-i-os-email-clients) or [Android open source email clients](https://forwardemail.net/blog/open-source/android-email-clients))
+    level: 0
+  activeDevelopment:
+    text: 'Yes'
+    level: 1
+  
 # ProtonMail
 - name: ProtonMail
   link: https://proton.me/
@@ -13,8 +59,8 @@ mailProviders:
     text: PGP
     level: 1
   openSource:
-    text: 'Yes'
-    level: 1
+    text: 'Only frontend'
+    level: 2
   onionSite:
     text: 'Yes'
     level: 1


### PR DESCRIPTION
Hi there!

We are the official team behind Forward Email at https://forwardemail.net and @forwardemail on GitHub.

**We are sharing a few highlights below about our service:**

* Unlike Proton Mail, Skiff, and Tuta we are actually 100% open-source on GitHub.
* We support ~250,000+ custom domain names using our MX service (this is _more_ than Proton Mail and Fastmail).
* Used by some notable organizations including:
  - The National Association for Amateur Radio (ARRL) (e.g. `dig arrl.net mx`)
  - Disney Ad Sales  (e.g. `dig disneyadsales.com mx`)
  - Tufts University (e.g. `dig alumni.tufts.edu mx`)
* You'll see in our PR that we already support OpenPGP and WKD.* We are planning to release calendar, contacts, and newsletter support in early 2024.
* You don't need a bridge or need to use proprietary apps to use us, you can simply use Thunderbird, Apple Mail, Outlook, or Gmail (we support standard SMTP, POP3, IMAP, API, etc).  We also do not rewrite your messages like Proton Mail does.
* Our website is translated to 25 languages (even our API, SMTP, POP3, and IMAP error messages are translated to your locale thanks to our work with `@ladjs/i18n` and `mandarin` (npm packages).  No other service comes close to us in terms of internationalization support.

Some questions we receive frequently are listed below, and we're happy to answer more.

P.S. We'd love to be included in your list and have already submitted a PR adhering to your existing code practices &ndash; happy to make changes as requested.  We're also available at `support@forwardemail.net` and we have a Matrix Chat channel `#forwardemail:matrix.org`.

## Do you have any reviews online anywhere?

Yes, we have a list of reviews on Trust Pilot at <https://www.trustpilot.com/review/forwardemail.net>.

## How can you claim to not increase prices?

We haven't since 2017 and don't plan to.  We abide by a set of [principles](https://forwardemail.net/blog/docs/best-quantum-safe-encrypted-email-service#principles); which keeps us in tune with our product and customer base.

## Do you have a status page?

Yes, our status page is linked in the Resources dropdown of our website, on the footer of every page, and our website also updates in real-time of any errors (and automatically presents a notification if necessary of _any_ issues).  We also have a TTI (time to inbox) monitoring feature that is public, it's on the footer of every page of our website and shows response times from Gmail, Outlook/Hotmail, and Apple iCloud.  An example screenshot is below from the present time (it updates every 5 min):

<img width="1072" alt="Screen Shot 2024-01-02 at 1 26 23 PM" src="https://github.com/Lissy93/email-comparison/assets/101466223/e1da7991-b482-44ee-87a7-efccf7992f57">

## How does your encrypted SQLite database feature work, and why SQLite?

We have an entire article dedicated to this at <https://forwardemail.net/blog/docs/best-quantum-safe-encrypted-email-service>.

Unlike every other email provider, we use individually encrypted SQLite mailboxes with `ChaCha20-Poly1305` encryption (using your strong passphrase, which only you have; you can audit our source to see that we do not store this anywhere and it's only presented client-side when rendered in-memory).   Other email providers use shared relational databases to store your emails, and most of them that use MongoDB and PostgreSQL have LUKS encryption, but NOT encryption at rest (of the actual database).  SQLite encryption allows us to have both LUKS encryption AND the actual database encrypted itself.  Even if a bad actor got access to the block storage device with `yourmailbox.sqlite` they still couldn't open it.  If a bad actor has access to the shared relational database of any other email service provider, they have full access to your mailbox.

## Do you have a FAQ section?

Yes, see our website FAQ section (note if you hit CMD+F or CTRL+F it will expand everything so you can easily search).  We haven't yet added something like Algolia or TypeSense yet but plan to do so in a privacy-focused way.