### PR TITLE
Correction: Mailfence does have a mobile app.

### DIFF
--- a/email-provider-data.yml
+++ b/email-provider-data.yml
@@ -227,8 +227,8 @@ mailProviders:
     text: Recovery Email Only
     level: 1
   mobileApp:
-    text: No (PWA Only)
-    level: 2
+    text: 'Yes'
+    level: 1
   activeDevelopment:
     text: 'Unknown'
     level: 0


### PR DESCRIPTION
As mentioned in [this Tweet](https://twitter.com/Mailfence/status/1752007713398063564) Mailfence does have a mobile app.

<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hi Alicia, thanks for including Mailfence in your list 😊<br><br>However we noticed a mistake: we DO actually have a mobile app, for both Android and iOS, which we rolled out last year.<br><br>Thanks for bringing the necessary correction 🙏</p>&mdash; Mailfence (@Mailfence) <a href="https://twitter.com/Mailfence/status/1752007713398063564?ref_src=twsrc%5Etfw">January 29, 2024</a></blockquote>

---

The mobile app is **not** open source. It is not available on F-Droid, or as direct download.

It is published on the following app stores:
- Android: https://play.google.com/store/apps/details?id=com.contactoffice.mailfence
- iOS: https://apps.apple.com/us/app/mailfence/id1628808776